### PR TITLE
Add `noargs_command` decorator to `__call__` magic method

### DIFF
--- a/call-to-non-callable.py
+++ b/call-to-non-callable.py
@@ -5,6 +5,17 @@ Synopsis::
 
     pytest call-to-non-callable.py
 """
+import functools
+
+
+def noargs_command(func):
+    @functools.wraps(func)
+    def wrapper(self, cmd, *args, **kwargs):
+        if len(args):
+            cmd.logger.critical('Command does not take any arguments.')
+            return
+        return func(self, cmd, *args, **kwargs)
+    return wrapper
 
 
 class Command(object):
@@ -13,6 +24,8 @@ class Command(object):
 
 
 class FooBarCommand(Command):
+
+    @noargs_command
     def __call__(self, cmd, *args, **kwargs):
         return f"{cmd}: foobar"
 


### PR DESCRIPTION
### About
The code works without issues, tests succeed.

However, when putting a Python decorator on a `__call__` magic method, CodeQL will raise a false positive notice that the code would be calling a non-callable. The corresponding rule is `py/call-to-non-callable`.

### Thoughts
Is there a way to annotate such code that CodeQL will accept it without further ado?

### References
- https://github.com/crate/crash/security/code-scanning/5